### PR TITLE
Find hook point easily

### DIFF
--- a/FindHookPoint.py
+++ b/FindHookPoint.py
@@ -1,0 +1,25 @@
+import os
+def findHook(path):
+    for i in os.walk(path+os.sep+"smali"+os.sep+"com"+os.sep+"netease"+os.sep+"cloudmusic"):
+        if "utils" not in i[0]:
+            for j in i[2]:
+                def openread(path,name):
+                    fi=open(path+os.sep+name)
+                    lines=fi.readlines()
+                    if "utils" in lines[1]:
+                        nam=name[0:name.find(".")]
+                        CONS=path.split(os.sep)
+                        length=len(lines[1])
+                        HOOK=lines[1][lines[1].find("utils/")+6:length]
+                        print "HOOK_UTILS = ","com.netease.cloudmusic.utils."+HOOK+"\r"
+                        print "HOOK_CONSTRUCTOR = ","com.netease.cloudmusic."+CONS[-2]+"."+CONS[-1]+"."+nam+"\n\n"
+                    fi.close()
+                if j.find(".")<=2:
+                    openread(i[0],j)
+#print "version 3.3.1\r"
+#findHook(r"D:\Android\output\c331")
+#print "version 3.2.1\r"
+#findHook(r"D:\Android\output\c321")
+#print "version 3.1.4\r"
+#findHook(r"D:\Android\output\c314")
+


### PR DESCRIPTION
Test 2.9.3 3.1.4 3.2.1  3.3.0 3.3.1

接收apktool反编译后的根目录返回hook参数.

Examples：

print "version 3.3.1\r"

findHook(r"D:\Android\output\c331")

print "version 3.2.1\r"

findHook(r"D:\Android\output\c321")

print "version 3.1.4\r"

findHook(r"D:\Android\output\c314")

Output：

version 3.3.1

HOOK_UTILS = com.netease.cloudmusic.utils.w;

HOOK_CONSTRUCTOR = com.netease.cloudmusic.cloudmusic.i.f

version 3.2.1

HOOK_UTILS = com.netease.cloudmusic.utils.n;

HOOK_CONSTRUCTOR = com.netease.cloudmusic.cloudmusic.i.b

version 3.1.4

HOOK_UTILS = com.netease.cloudmusic.utils.u;

HOOK_CONSTRUCTOR = com.netease.cloudmusic.cloudmusic.i.f